### PR TITLE
[Content] Expand session 1194670 description

### DIFF
--- a/content/sessions/general-1194670.md
+++ b/content/sessions/general-1194670.md
@@ -7,7 +7,13 @@ stype: "Chinese Session"
 room: "Mtn BaiWang Hall"
 ---
 
-量子機器學習（QML）雖然被寄予高度期待，但在實務落地時，常常首先卡在資料編碼階段：在量子運算開始之前，必須先把傳統特徵向量轉換成量子態；當 qubit 數量提升後，這個步驟會快速成為整體流程中的主要瓶頸。Apache Mahout 的 QDP（Quantum Data Plane）正是為了解決這個問題而設計，其定位是將傳統資料高效編碼成量子態的 GPU 加速資料平面。
+Quantum machine learning (QML) holds great promise, but practical implementations often encounter a major bottleneck before quantum computation even begins. Classical feature vectors must first be prepared and encoded into quantum states. As data dimensionality and the number of qubits increase, this step can dominate end-to-end execution time and limit the scalability of QML workflows.
+
+In this session, we will introduce Quantum Data Plane (QDP), a GPU-accelerated data plane being developed in Apache Mahout to make quantum data encoding more efficient and scalable. QDP treats data encoding as a dedicated execution layer rather than a one-off preprocessing task. We will explain its motivation, overall architecture, integration with Apache Mahout, and how GPU parallelism can help address the encoding bottleneck.
+
+Drawing on our implementation experience, we will share key design choices and lessons learned from building QDP. We will discuss where GPU acceleration provides the greatest value, the limitations and trade-offs of this approach, and how the project may evolve through open-source collaboration.
+
+Attendees will leave with a practical understanding of data preparation challenges in QML and a broader perspective on how Apache Mahout can connect classical machine learning infrastructure with emerging quantum computing workflows.
 
 ### Speakers:
 

--- a/content/sessions/general-1194670.zh.md
+++ b/content/sessions/general-1194670.zh.md
@@ -2,12 +2,18 @@
 title: "加速量子机器学习：在 Apache Mahout 中构建 GPU 加速数据平面"
 date: "2026-08-08T16:15:00"
 track: "general"
-presenters: "张杰凯, Guan-Hua Wen"
+presenters: "张杰凯, 温冠华"
 stype: "中文演讲"
 room: "百望山会议室"
 ---
 
-量子机器学习（QML）虽然被寄予高度期待，但在实际落地时，常常首先卡在数据编码阶段：在量子计算开始之前，必须先把经典特征向量转换成量子态；当 qubit 数量增加后，这一步骤会迅速成为整个流程中的主要瓶颈。Apache Mahout 的 QDP（Quantum Data Plane，量子数据平面）正是为解决这个问题而设计，其定位是将经典数据高效编码成量子态的 GPU 加速数据平面。
+量子机器学习（QML）虽然前景广阔，但在实际应用中，往往会在量子计算开始之前遇到一个主要瓶颈。经典特征向量必须先经过处理并编码成量子态。随着数据维度和量子比特数量的增加，这一步骤可能占据端到端执行时间的大部分，并限制 QML 工作流的可扩展性。
+
+本次演讲将介绍 Quantum Data Plane（QDP，量子数据平面）。这是 Apache Mahout 中正在开发的 GPU 加速数据平面，旨在让量子数据编码更加高效且更具可扩展性。QDP 将数据编码视为一个专门的执行层，而不是一次性的预处理任务。我们将介绍其设计动机、整体架构、与 Apache Mahout 的集成方式，以及 GPU 并行计算如何帮助解决数据编码瓶颈。
+
+结合实际开发经验，我们将分享构建 QDP 过程中的关键设计选择与经验总结，并讨论 GPU 加速最能发挥价值的场景、这种方法的局限与取舍，以及项目未来如何通过开源协作持续发展。
+
+听众将了解 QML 中数据准备所面临的实际挑战，并从更广泛的视角认识 Apache Mahout 如何连接经典机器学习基础设施与新兴的量子计算工作流。
 
 ### 讲师:
 
@@ -21,6 +27,6 @@ room: "百望山会议室"
 
 <img src="https://cdn.sessionize.com/image/3ff9-400o400o2-WwwDMsRTLkU2W9JqkZaTxF.jpg" width="200" /><br/>
 
-Guan-Hua Wen：Apache Mahout Committer
+温冠华：Apache Mahout Committer
 
 微软研发实习生


### PR DESCRIPTION
## Summary

- Expand the English description for session `general-1194670` with additional context about:
  - QML data preparation challenges
  - Apache Mahout Quantum Data Plane (QDP)
  - GPU acceleration and project design considerations
  - Expected takeaways for attendees
- Add the corresponding expanded Simplified Chinese description.
- Update Guan-Hua Wen’s name to `温冠华` on the Chinese session page.
