### PR TITLE
Add Fei Wang as a speaker for session datalake-1211108

### DIFF
--- a/content/sessions/datalake-1211108.md
+++ b/content/sessions/datalake-1211108.md
@@ -2,7 +2,7 @@
 title: "Apache Iceberg V3 in Production: Lessons from a Large-Scale Deployment"
 date: "2026-08-08T14:00:00"
 track: "datalake"
-presenters: "Yuming Wang"
+presenters: "Yuming Wang, Fei Wang"
 stype: "Chinese Session"
 room: "MainRoom - YiHe Hall"
 ---
@@ -17,3 +17,8 @@ Apache Iceberg V3 brings powerful capabilities, but running it reliably in produ
 Yuming Wang: eBay, Compute, Lakehouse
 
 Yuming Wang is a member of the Apache Spark Project Management Committee (PMC) and currently leads the build-out and evolution of his company’s compute platform. He focuses on architecting, optimizing, and operating Spark at production scale, while also driving the implementation and operation of a Lakehouse architecture based on Apache Iceberg. He is committed to turning cutting-edge open-source data technologies into reliable and efficient enterprise-grade production systems.
+
+
+Fei Wang: eBay, Hadoop
+
+Fei Wang is a PMC member of both Apache Kyuubi and Apache Celeborn, currently focusing on the development and evolution of enterprise computing platforms. He specializes in distributed computing, Spark engine optimization, and Lakehouse architecture based on Apache Iceberg, dedicated to translating open-source data technologies into stable and efficient enterprise-grade computing services.

--- a/content/sessions/datalake-1211108.zh.md
+++ b/content/sessions/datalake-1211108.zh.md
@@ -2,7 +2,7 @@
 title: "生产环境中的 Apache Iceberg V3：来自大规模部署的经验教训"
 date: "2026-08-08T14:00:00"
 track: "datalake"
-presenters: "Yuming Wang"
+presenters: "Yuming Wang, Fei Wang"
 stype: "中文演讲"
 room: "主会场 - 颐和厅"
 ---
@@ -17,3 +17,8 @@ Apache Iceberg V3 带来了强大的能力，但要可靠地在生产环境中�
 Yuming Wang：eBay，计算与湖仓
 
 Yuming Wang 是 Apache Spark 项目管理委员会（PMC）的成员，目前负责公司计算平台的建设与演进。他专注于在生产规模下对 Spark 进行架构设计、优化和运营，同时推动基于 Apache Iceberg 的湖仓架构的落地与运营。他致力于把前沿的开源数据技术转化为可靠、高效的企业级生产系统。
+
+
+Fei Wang：eBay，Hadoop
+
+王斐是 Apache Kyuubi 与 Apache Celeborn 项目管理委员会（PMC）成员，目前参与公司计算平台的建设与演进。他专注于分布式计算、Spark 引擎优化以及基于 Apache Iceberg 的 Lakehouse 架构实践，致力于将开源数据技术转化为稳定高效的企业级计算服务。


### PR DESCRIPTION
## What changed
- added Fei Wang to the `presenters` front matter for session `datalake-1211108`
- added Fei Wang speaker details to both the English and Chinese session pages

## Why
- the session needs one more speaker listed on the site

## Validation
- compared the two edited Markdown files against upstream `master`
- confirmed the diff is limited to the requested speaker additions
- independent maintainer-style review reported `READY FOR PR`
- local Hugo build was intentionally skipped per requester instruction
