### PR TITLE
Update speaker information for session dataai-1206062

### DIFF
--- a/content/sessions/dataai-1206062.md
+++ b/content/sessions/dataai-1206062.md
@@ -2,7 +2,7 @@
 title: "Vector Lakebase: Rethinking Data Infrastructure for AI-Native Applications"
 date: "2026-08-08T16:15:00"
 track: "dataai"
-presenters: "Xiaofan Luan"
+presenters: "Li Liu"
 stype: "Chinese Session"
 room: "JingMing Hall"
 ---
@@ -30,8 +30,8 @@ Finally, we’ll discuss how AI-native data infrastructure is evolving — and w
 ### Speakers:
 
 
-<img src="https://cdn.sessionize.com/image/2fc1-400o400o1-hq3xZpvWNPBgprs3caTFZE.png" width="200" /><br/>
+<img src="https://cdn.sessionize.com/image/42ca-200o200o2-hbHvxYKUbcHCu2jkKC9EHg.jpg" width="200" /><br/>
 
-Xiaofan Luan: Zilliz, Partner and Director of Engineering 
+Li Liu: Director of Engineering
 
-Xiaofan Luan, Partner and Director of Engineering of Zilliz, member of Technical Advisory Committee of LF AI & Data Foundation. He worked successively in the US headquarters of Oracle and Hedvig, a software defined storage startup. He joined Alibaba cloud database team and was in charge of the development of  NoSQL database HBase and  Lindorm. Xiaofan Luan holds a master's degree in Electronic Computer Engineering from Cornell University.
+Li Liu is Director of Engineering at Zilliz and Technical Lead for Milvus. With many years of experience in databases and big-data processing, he now leads the development and maintenance of Zilliz’s core database systems. Previously, he was a Senior Engineer at Meta, where he designed and built the company’s streaming data framework for advertising. Li holds a Master of Information Technology degree from Carnegie Mellon University.

--- a/content/sessions/dataai-1206062.zh.md
+++ b/content/sessions/dataai-1206062.zh.md
@@ -2,7 +2,7 @@
 title: "向量湖仓（Vector Lakebase）：重新思考面向 AI 原生应用的数据基础设施"
 date: "2026-08-08T16:15:00"
 track: "dataai"
-presenters: "Xiaofan Luan"
+presenters: "刘力"
 stype: "中文演讲"
 room: "静明厅"
 ---
@@ -30,8 +30,8 @@ room: "静明厅"
 ### 讲师:
 
 
-<img src="https://cdn.sessionize.com/image/2fc1-400o400o1-hq3xZpvWNPBgprs3caTFZE.png" width="200" /><br/>
+<img src="https://cdn.sessionize.com/image/42ca-200o200o2-hbHvxYKUbcHCu2jkKC9EHg.jpg" width="200" /><br/>
 
-Xiaofan Luan：Zilliz 合伙人兼工程总监
+刘力：工程总监
 
-Xiaofan Luan 是 Zilliz 合伙人兼工程总监，LF AI & Data 基金会技术咨询委员会（Technical Advisory Committee）成员。他先后任职于 Oracle 美国总部以及软件定义存储初创公司 Hedvig。之后加入阿里云数据库团队，负责 NoSQL 数据库 HBase 与 Lindorm 的研发。Xiaofan Luan 拥有康奈尔大学电子计算机工程硕士学位。
+刘力现任 Zilliz 工程总监兼 Milvus 技术负责人。他在数据库和大数据处理领域拥有多年经验，目前负责 Zilliz 核心数据库系统的开发与维护。此前，他曾任 Meta 高级工程师，设计并构建了该公司面向广告业务的流式数据框架。刘力拥有卡内基梅隆大学信息技术硕士学位。


### PR DESCRIPTION
## What changed
- replaced Xiaofan Luan with Li Liu in the presenters front matter for session dataai-1206062
- updated the speaker photo, title, and biography on both English and Chinese session pages
- kept English speaker information in English and Chinese speaker information in Chinese

## Why
- the session speaker information needs to be corrected

## Validation
- confirmed the diff is limited to the two session Markdown files
- validated both YAML front matter blocks
- confirmed no Xiaofan Luan references remain under content
- confirmed the new speaker image URL returns HTTP 200
- local Hugo build was skipped because Hugo is not installed in the environment