### PR TITLE
Add Zeyu Zhang as a speaker for session  iot-1213290

### DIFF
--- a/content/sessions/iot-1213290.md
+++ b/content/sessions/iot-1213290.md
@@ -2,7 +2,7 @@
 title: "From Time Series Data to Specialized Data Management"
 date: "2026-08-09T15:45:00"
 track: "iot"
-presenters: "洪胤 张"
+presenters: "洪胤 张, 泽宇 张"
 stype: "Chinese Session"
 room: "Mtn BaiWang Hall"
 ---
@@ -17,3 +17,9 @@ This session focuses on the evolution of data management from time-series data t
 洪胤 张: Apache IoTDB PMC, PhD student at Tsinghua University
 
 Zhang Hongyin, Apache IoTDB PMC, PhD student of Tsinghua University, is currently responsible for Apache IoTDB memory management, system monitoring, and standardized testing.
+
+<img src="https://cdn.sessionize.com/image/33e2-200o200o2-4mKTrpL6Yz5bgGHqaSVaVK.jpg" width="200" /><br/>
+
+泽宇 张: Graduate student at Tsinghua University
+
+Zhang Zeyu, Graduate student of Tsinghua University, is currently focusing on Apache IoTDB agent-friendly system, along with time series model training and reasoning.

--- a/content/sessions/iot-1213290.zh.md
+++ b/content/sessions/iot-1213290.zh.md
@@ -2,7 +2,7 @@
 title: "从时序数据到专业化数据管理"
 date: "2026-08-09T15:45:00"
 track: "iot"
-presenters: "洪胤 张"
+presenters: "洪胤 张, 泽宇 张"
 stype: "中文演讲"
 room: "百望山会议室"
 ---
@@ -17,3 +17,9 @@ room: "百望山会议室"
 洪胤 张: Apache IoTDB PMC, PhD student at Tsinghua University
 
 张洪胤，Apache IoTDB PMC，清华大学博士研究生，目前负责 Apache IoTDB 的内存管理、系统监控和标准化测试工作。
+
+<img src="https://cdn.sessionize.com/image/33e2-200o200o2-4mKTrpL6Yz5bgGHqaSVaVK.jpg" width="200" /><br/>
+
+泽宇 张: Graduate student at Tsinghua University
+
+张泽宇，清华大学本科毕业生，目前聚焦 Apache IoTDB agent-friendly system，以及时间序列模型训练和推理。


### PR DESCRIPTION
# What changed
* added Zeyu Zhang to the presenters front matter for session iot-1213290
* added Zeyu Zhang speaker details to both the English and Chinese session pages
# Why
* Because the original speaker Hongyin Zhang was away on a business trip, another speaker was needed to give the presentation on-site. So the session needs one more speaker listed on the site
# Validation
* compared the two edited Markdown files against upstream master
* confirmed the diff is limited to the requested speaker additions
* independent maintainer-style review reported READY FOR PR
* local Hugo build was intentionally skipped per requester instruction
