### PR TITLE
Update session dataai-1300514 title and abstract

### DIFF
--- a/content/sessions/dataai-1300514.md
+++ b/content/sessions/dataai-1300514.md
@@ -1,5 +1,5 @@
 ---
-title: "Building Agentic Payment & Data Monetization Layer for AI on Solana"
+title: "Who Pays for the Data? Metering Apache Pipelines for AI Agents"
 date: "2026-08-08T16:45:00"
 track: "dataai"
 presenters: "Mike Ma"
@@ -7,7 +7,7 @@ stype: "Chinese Session"
 room: "JingMing Hall"
 ---
 
-Introducing mainstream agentic payment protocols in apache ecosystem, agentic payment gateway built by Solana, successful case study of data monetization open-source projects, and how blockchain protocols can bootstrap open source agent economy. 
+Solana's data infrastructure already runs on Apache — Kafka, Parquet, Arrow, DataFusion, Airflow, Beam — used by Coinbase, Allium, Blockdaemon and other ecosystem teams. What's missing from the stack is metering: nothing today answers "who pays for this call, how much, and to whom?" This talk walks through how the busiest open-source streaming pipelines on Solana are empowered by the Apache stack, proposes adding an x402 (HTTP 402 Payment Required) middleware at the data-plane gateway so open-source projects can charge AI agents per call, and reviews real success cases of onchain data monetization.
 
 ### Speakers:
 

--- a/content/sessions/dataai-1300514.zh.md
+++ b/content/sessions/dataai-1300514.zh.md
@@ -1,5 +1,5 @@
 ---
-title: "在 Solana 上为 AI 构建智能体支付与数据变现层"
+title: "谁为数据买单？为 AI Agent 计量 Apache 数据管道"
 date: "2026-08-08T16:45:00"
 track: "dataai"
 presenters: "Mike Ma"
@@ -7,7 +7,7 @@ stype: "中文演讲"
 room: "静明厅"
 ---
 
-介绍 Apache 生态中主流的智能体支付协议、由 Solana 构建的智能体支付网关、数据变现开源项目的成功案例，以及区块链协议如何引导开源智能体经济的发展。
+Solana 的数据基础设施早已运行在 Apache 之上——Kafka、Parquet、Arrow、DataFusion、Airflow、Beam 已被 Coinbase、Allium、Blockdaemon 等生态团队广泛采用。而 Apache 栈中缺失的一环是"计量"：目前没有任何组件能回答"这次调用谁来付、付多少、付给谁？"。本次分享将呈现 Solana 上最繁忙的开源数据管道如何依托 Apache 栈，并提出在数据面网关引入 x402（HTTP 402 Payment Required）中间件的方案，让开源项目可以对 AI Agent 按次计费；同时回顾链上数据变现的真实成功案例。
 
 ### 讲师:
 


### PR DESCRIPTION
## Summary

Sync the session page for `dataai-1300514` with the latest deck / agenda.

- New title: **"Who Pays for the Data? Metering Apache Pipelines for AI Agents"** (previously *Building Agentic Payment & Data Monetization Layer for AI on Solana*)
- Rewrote the English and Chinese abstracts to match the current talk outline:
  1. How Solana's busiest open-source data pipelines are built on the Apache stack (Kafka, Parquet, Arrow, DataFusion, Airflow, Beam — used by Coinbase, Allium, Blockdaemon).
  2. A proposal to add x402 (HTTP 402 Payment Required) metering middleware at the data-plane gateway so open-source projects can charge AI agents per call.
  3. Real success cases of onchain data monetization.

Only the `title` and abstract paragraph change in both the English and Chinese session files; date, track, presenter, session type, and room are unchanged.

## Test plan

- [x] `dataai-1300514.md` — title + abstract updated
- [x] `dataai-1300514.zh.md` — 标题与摘要更新
- [x] `git diff` limited to the two intended files (4 lines each)